### PR TITLE
Fixed confirmation url.

### DIFF
--- a/src/Sylius/Sandbox/Bundle/NewsletterBundle/Resources/views/Confirmation/email.html.twig
+++ b/src/Sylius/Sandbox/Bundle/NewsletterBundle/Resources/views/Confirmation/email.html.twig
@@ -1,7 +1,1 @@
-<strong>Thank you</strong> for subscribing. Confirm it...
-
-<br /><br />
-
-<a href="{{ path('sylius_newsletter_subscriber_confirm', {'token': subscriber.confirmationToken}) }}">{{ path('sylius_newsletter_subscriber_confirm', {'token': subscriber.confirmationToken}) }}</a>...
-
-<br /><br />
+<strong>Thank you</strong> for subscribing. Confirm it by clicking <a href="{{ url('sylius_newsletter_subscriber_confirm', {'token': subscriber.confirmationToken}) }}">this link</a>.


### PR DESCRIPTION
Used twig url helper for confirmation link. Now one can really confirm by just clicking the link in email.
