### PR TITLE
Installation and phpunit coverage config fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "sylius/plugins-bundle":               "dev-master",
         "sylius/guard-bundle":                 "dev-master",
         "sylius/addressing-bundle":            "dev-master",
-        "sylius/installer-bundle":             "dev-master"
+        "sylius/installer-bundle":             "dev-master",
+        "sylius/catalog-bundle":               "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/src/Sylius/Sandbox/Bundle/AssortmentBundle/Form/Type/ProductFormType.php
+++ b/src/Sylius/Sandbox/Bundle/AssortmentBundle/Form/Type/ProductFormType.php
@@ -11,7 +11,7 @@
 
 namespace Sylius\Sandbox\Bundle\AssortmentBundle\Form\Type;
 
-use Sylius\Bundle\AssortmentBundle\Form\Type\ProductFormType as BaseProductFormType;
+use Sylius\Bundle\AssortmentBundle\Form\Type\ProductType as BaseProductFormType;
 
 use Symfony\Component\Form\FormBuilder;
 


### PR DESCRIPTION
- Added missing catalog bundle in composer.json
- Make phpunit coverage possible. (after Sylius/SyliusAssortmentBundle@fc4ceb01d1bf52419cd4ccd3779cf9dc123899cc not work)
