### PR TITLE
Symfony form fixes.

### DIFF
--- a/src/Sylius/Sandbox/Bundle/CoreBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Sandbox/Bundle/CoreBundle/Resources/views/forms.html.twig
@@ -56,7 +56,7 @@
 {% block datetime_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_compound') }}
+        {{ block('form_widget_simple') }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_errors(form.date) }}
@@ -72,7 +72,7 @@
 {% block date_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_compound') }}
+        {{ block('form_widget_simple') }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             <div class="form-inline">
@@ -90,7 +90,7 @@
 {% block time_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
-        {{ block('form_widget_compound') }}
+        {{ block('form_widget_simple') }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}


### PR DESCRIPTION
I made a mistake in the first fix.

One question: why are all this blocks copied instead extending them from `form_div_layout.html.twig`? Copy-paste makes it hard to maintain.
