### PR TITLE
patch for easy change namespace level

### DIFF
--- a/src/Sylius/Sandbox/Bundle/CoreBundle/Composer/ScriptHandler.php
+++ b/src/Sylius/Sandbox/Bundle/CoreBundle/Composer/ScriptHandler.php
@@ -21,7 +21,11 @@ class ScriptHandler
         $IO = $event->getIO();
         $composer = $event->getComposer();
 
-        $symlinkTarget = __DIR__.'/../../../../../../vendor/twitter/bootstrap';
+        $dir = __DIR__;
+        while (!is_dir($dir.'/vendor/twitter/bootstrap'))
+            $dir = dirname($dir);
+
+        $symlinkTarget = $dir.'/vendor/twitter/bootstrap';
         $symlinkName = __DIR__.'/../Resources/public/bootstrap';
 
         if (!@readlink($symlinkName)) {


### PR DESCRIPTION
Sandbox is an example, it can be move to a folder on a different level 
 to start on it - so it would be much easier.

Now need one global replace for rename this.
