### PR TITLE
Show form errors.

### DIFF
--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Taxon/_form.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Taxon/_form.html.twig
@@ -1,3 +1,4 @@
+{{ form_errors(form) }}
 <fieldset>
     {{ form_row(form.taxonomy) }}
     {{ form_row(form.name, {'attr': {'class': 'input-xlarge'}}) }}

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Taxonomy/_form.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Taxonomy/_form.html.twig
@@ -1,3 +1,4 @@
+{{ form_errors(form) }}
 <fieldset>
     {{ form_row(form.name, {'attr': {'class': 'input-xlarge'}}) }}
 </fieldset>


### PR DESCRIPTION
`Symfony\Component\Validator\Constraints\Valid` constraint adds errors to form, not fields.

``` xml
<property name="root">
        <constraint name="Valid" />
</property>
```

So, in order to be visible, we must render them.
