### PR TITLE
Moved FOSCommentBundle JavaScripts before </body> tag

### DIFF
--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/show.html.twig
@@ -112,7 +112,18 @@
 
 <hr />
 <div class="well">
-    {% include 'FOSCommentBundle:Thread:async.html.twig' with {'id': product.commentThreadId} %}
+    <div id="fos_comment_thread"></div>
 </div>
 <hr />
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script type="text/javascript">
+        var fos_comment_thread_id = '{{ product.CommentThreadId }}';
+        var fos_comment_thread_api_base_url = '{{ path('fos_comment_get_threads') }}';
+    </script>
+    {% javascripts '@FOSCommentBundle/Resources/assets/js/comments.js' %}
+        <script async="" type="text/javascript" src="{{ asset_url }}"></script>
+    {% endjavascripts %}
 {% endblock %}


### PR DESCRIPTION
Changes in product show.html.twig. Now FOSCommentBundle is loading after jQuery and div #fos_comment_thread.
