### PR TITLE
PR: Currency Symbol configurable.

### DIFF
--- a/sandbox/config/container/base.yml
+++ b/sandbox/config/container/base.yml
@@ -26,6 +26,8 @@ twig:
             - 'SyliusSandboxBundle::forms.html.twig'
     debug:            %kernel.debug%
     strict_variables: %kernel.debug%
+    globals:
+        currency:     %sylius.currency%
 
 assetic:
     debug:          %kernel.debug%

--- a/sandbox/config/container/parameters.yml.dist
+++ b/sandbox/config/container/parameters.yml.dist
@@ -21,3 +21,5 @@ parameters:
     sylius.secret: 7105d4542c26b7dec214bfab78d8da51b
 
     sylius.cache:             apc
+
+    sylius.currency:          '&euro;'

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/_form.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/_form.html.twig
@@ -61,7 +61,7 @@
                 </td>
                 <td>
                     <div class="input-append pull-right">
-                    <input type="text" id="sylius-sales-order-total" class="disabled input-small" disabled="disabled" value="0.00"/><span class="add-on">&euro;</span>
+                    <input type="text" id="sylius-sales-order-total" class="disabled input-small" disabled="disabled" value="0.00"/><span class="add-on">{{ currency|raw }}</span>
                     </div>
                 </td>
             </tr>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/macros.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/macros.html.twig
@@ -17,7 +17,7 @@
         {% for order in orders %}
         <tr>
             <td>{{ order.id }}</td>
-            <td>{{ order.total }} &euro;</td>
+            <td>{{ order.total }} {{ currency|raw }}</td>
             <td>
                 <a href="{{ path('sylius_sandbox_backend_user_show', {'id': order.user.id}) }}" class="btn">
                 <i class="icon-user"></i> &nbsp; {{ order.user.username }}

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/show.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Order/show.html.twig
@@ -22,19 +22,19 @@
             </tr>
             <tr>
                 <td><strong>total</strong></td>
-                <td>{{ order.total }} &euro;</td>
+                <td>{{ order.total }} {{ currency|raw }}</td>
             </tr>
             <tr>
                 <td><strong>items total</strong></td>
-                <td>{{ order.itemsTotal }} &euro;</td>
+                <td>{{ order.itemsTotal }} {{ currency|raw }}</td>
             </tr>
             <tr>
                 <td><strong>tax total</strong></td>
-                <td>{{ order.taxTotal }} &euro;</td>
+                <td>{{ order.taxTotal }} {{ currency|raw }}</td>
             </tr>
             <tr>
                 <td><strong>shipping total</strong></td>
-                <td>{{ order.shippingTotal }} &euro;</td>
+                <td>{{ order.shippingTotal }} {{ currency|raw }}</td>
             </tr>
             <tr>
                 <td><strong>user</strong></td>
@@ -233,12 +233,12 @@
             <td>{{ item.quantity }}</td>
             <td>
                 <span class="pull-right">
-                {{ item.unitPrice }} &euro;
+                {{ item.unitPrice }} {{ currency|raw }}
                 </span>
             </td>
             <td>
                 <span class="pull-right">
-                {{ item.total }} &euro;
+                {{ item.total }} {{ currency|raw }}
                 </span>
             </td>
         </tr>
@@ -248,7 +248,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>Items total</strong>: {{ order.itemsTotal }} &euro;
+                <strong>Items total</strong>: {{ order.itemsTotal }} {{ currency|raw }}
                 </span>
             </td>
         </tr>
@@ -257,13 +257,13 @@
             <p><strong>Taxes</strong></p>
             <ul>
             {% for taxAdjustment in order.taxAdjustments %}
-                <li>{{ taxAdjustment.description }} {{ taxAdjustment.amount }} &euro;</li>
+                <li>{{ taxAdjustment.description }} {{ taxAdjustment.amount }} {{ currency|raw }}</li>
             {% endfor %}
             </ul>
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>Tax total</strong>: {{ order.taxTotal }} &euro;
+                <strong>Tax total</strong>: {{ order.taxTotal }} {{ currency|raw }}
                 </span>
             </td>
         </tr>
@@ -272,13 +272,13 @@
             <p><strong>Shipping</strong></p>
             <ul>
             {% for adjustment in order.shippingAdjustments %}
-                <li>{{ adjustment.description }} {{ adjustment.amount }} &euro;</li>
+                <li>{{ adjustment.description }} {{ adjustment.amount }} {{ currency|raw }}</li>
             {% endfor %}
             </ul>
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>Shipping total</strong>: {{ order.shippingTotal }} &euro;
+                <strong>Shipping total</strong>: {{ order.shippingTotal }} {{ currency|raw }}
                 </span>
             </td>
         </tr>
@@ -287,7 +287,7 @@
             </td>
             <td colspan="2">
                 <span class="pull-right">
-                <strong>Total</strong>: {{ order.total }} &euro;
+                <strong>Total</strong>: {{ order.total }} {{ currency|raw }}
                 </span>
             </td>
         </tr>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Product/show.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Product/show.html.twig
@@ -79,7 +79,7 @@
             </td>
             <td>{{ product.taxCategory|default('Undefined') }}</td>
             <td>{{ product.masterVariant.shippingCategory|default('Undefined') }}</td>
-            <td>{{ product.price }} &euro;</td>
+            <td>{{ product.price }} {{ currency|raw }}</td>
         </tr>
     </tbody>
 </table>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Variant/macros.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Variant/macros.html.twig
@@ -32,7 +32,7 @@
                     {% endfor %}
                 </ul>
             </td>
-            <td>{{ variant.price }} &euro;</td>
+            <td>{{ variant.price }} {{ currency|raw }}</td>
             <td>{{ badge(variant.onHand, variant.inStock ? 'success' : 'important') }} in stock</td>
             <td>
                 {% if variant.availableOnDemand %}

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Variant/show.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Backend/Variant/show.html.twig
@@ -67,7 +67,7 @@
                 </ul>
             </td>
             <td>{{ variant.shippingCategory|default('Undefined') }}</td>
-            <td>{{ variant.price }} &euro;</td>
+            <td>{{ variant.price }} {{ currency|raw }}</td>
         </tr>
     </tbody>
 </table>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Checkout/Step/finalize.html.twig
@@ -121,12 +121,12 @@
                 <td>{{ item.quantity }}</td>
                 <td>
                     <span class="pull-right">
-                    {{ item.unitPrice }} &euro;
+                    {{ item.unitPrice }} {{ currency|raw }}
                     </span>
                 </td>
                 <td>
                     <span class="pull-right">
-                    {{ item.total }} &euro;
+                    {{ item.total }} {{ currency|raw }}
                     </span>
                 </td>
             </tr>
@@ -136,13 +136,13 @@
                 <p><strong>Taxes</strong></p>
                 <ul>
                 {% for adjustment in order.taxAdjustments %}
-                    <li>{{ adjustment.description }} {{ adjustment.amount }} &euro;</li>
+                    <li>{{ adjustment.description }} {{ adjustment.amount }} {{ currency|raw }}</li>
                 {% endfor %}
                 </ul>
                 </td>
                 <td colspan="2">
                     <span class="pull-right">
-                    <strong>Tax total</strong>: {{ order.taxTotal }} &euro;
+                    <strong>Tax total</strong>: {{ order.taxTotal }} {{ currency|raw }}
                     </span>
                 </td>
             </tr>
@@ -151,13 +151,13 @@
                 <p><strong>Shipping</strong></p>
                 <ul>
                 {% for adjustment in order.shippingAdjustments %}
-                    <li>{{ adjustment.description }} {{ adjustment.amount }} &euro;</li>
+                    <li>{{ adjustment.description }} {{ adjustment.amount }} {{ currency|raw }}</li>
                 {% endfor %}
                 </ul>
                 </td>
                 <td colspan="2">
                     <span class="pull-right">
-                    <strong>Shipping total</strong>: {{ order.shippingTotal }} &euro;
+                    <strong>Shipping total</strong>: {{ order.shippingTotal }} {{ currency|raw }}
                     </span>
                 </td>
             </tr>
@@ -166,7 +166,7 @@
                 </td>
                 <td colspan="2">
                     <span class="pull-right">
-                    <strong>Total</strong>: {{ order.total }} &euro;
+                    <strong>Total</strong>: {{ order.total }} {{ currency|raw }}
                     </span>
                 </td>
             </tr>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/_single.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/_single.html.twig
@@ -6,7 +6,7 @@
     </div>
     <div class="span9">
         {% if not product.hasOptions %}
-            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} &euro;</span>
+            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} {{ currency|raw }}</span>
         {% endif %}
         <h3>{{ product.name }}</h3>
         <p>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/_singleGrid.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/_singleGrid.html.twig
@@ -11,7 +11,7 @@
         </h4>
 
         {% if not product.hasOptions %}
-            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} &euro;</span>
+            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} {{ currency|raw }}</span>
         {% endif %}
 
     <p>{{ product.description|slice(0, 50) }}...</p>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/show.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/Product/show.html.twig
@@ -17,7 +17,7 @@
     </div>
     <div class="span5">
         {% if not product.hasOptions %}
-            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} &euro;</span>
+            <span class="label label-price label-success pull-right"><strong>Price</strong>: {{ product.price }} {{ currency|raw }}</span>
         {% endif %}
         <h3>{{ product.name }}</h3>
         <p>
@@ -70,7 +70,7 @@
                         {% endif %}
                     </td>
                     <td>
-                        <span class="label label-success">{{ variant.price }} &euro;</span>
+                        <span class="label label-success">{{ variant.price }} {{ currency|raw }}</span>
                     </td>
                     <td>
                     {% if sylius_inventory_is_available(variant) %}

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/sidebar.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/Frontend/sidebar.html.twig
@@ -1,6 +1,6 @@
 <div class="well">
 <h3>My cart</h3>
-<strong>{{ sylius_cart_get().totalItems }}</strong> items, <strong>{{ sylius_cart_get().total }}</strong> &euro;
+<strong>{{ sylius_cart_get().totalItems }}</strong> items, <strong>{{ sylius_cart_get().total }}</strong> {{ currency|raw }}
 <hr />
 <a href="{{ path('sylius_cart_summary') }}" class="btn btn-primary">show cart <i class="icon-shopping-cart icon-white"></i></a>
 </div>

--- a/src/Sylius/Bundle/SandboxBundle/Resources/views/forms.html.twig
+++ b/src/Sylius/Bundle/SandboxBundle/Resources/views/forms.html.twig
@@ -13,12 +13,12 @@
     </td>
     <td>
         <div class="input-append pull-right">
-        <input type="text" id="{{ id }}-unitPrice" class="disabled input-small" disabled="disabled" value="{{ value is not empty ? value.unitPrice : '0.00' }}"/><span class="add-on">&euro;</span>
+        <input type="text" id="{{ id }}-unitPrice" class="disabled input-small" disabled="disabled" value="{{ value is not empty ? value.unitPrice : '0.00' }}"/><span class="add-on">{{ currency|raw }}</span>
         </div>
     </td>
     <td>
         <div class="input-append pull-right">
-        <input type="text" id="{{ id }}-total" class="disabled input-small" disabled="disabled" value="{{ value is not empty ? value.unitPrice * value.quantity : '0.00' }}"/><span class="add-on">&euro;</span>
+        <input type="text" id="{{ id }}-total" class="disabled input-small" disabled="disabled" value="{{ value is not empty ? value.unitPrice * value.quantity : '0.00' }}"/><span class="add-on">{{ currency|raw }}</span>
         </div>
     </td>
 </tr>


### PR DESCRIPTION
Hi,

In Switzerland we do not use the Euro Symbol for our currency. It might be handy for others to configure the Symbol to 'CHF' or '$'.

<b>Attention</b>: as only in parameters.yml.dist configured it could break current installations.

Don't know if twig global is optimal and if it should be html entity or just the UTF-8 character €.

Greetings from Switzerland
Patrick
